### PR TITLE
Respect `.gitignore` etc.

### DIFF
--- a/URL-tester.ps1
+++ b/URL-tester.ps1
@@ -56,7 +56,37 @@ switch ($target.Attributes) {
 		break
 	}
 	Directory {
-		$files = @(Get-ChildItem $target -File -Recurse -Exclude 'node_modules' | Where-Object { $_.Extension -eq '.json' })
+		$baseFiles = Get-ChildItem $target -File
+		$i = $baseFiles.Name.IndexOf('.gitignore')
+		if ($i -ne -1) {
+			$gitignore = Get-Content $baseFiles[$i] -Encoding utf8 |
+				Where-Object { $_ -and $_ -notmatch '^#' } |
+				ForEach-Object {
+					# Escape .
+					# Convert * to any character
+					# Convert ? to any single character
+					# dir/ matches sub-paths
+					# /xyz matches only within root
+					# [!...] becomes [^...]
+					# Make path-separators neutral
+					$_ -replace '\.', '\.' `
+						-replace '\*', '.*' `
+						-replace '\?', '.' `
+						-replace '/$', '/.+' `
+						-replace '^/', [Regex]::Escape($target) `
+						-replace '\[!([^]]+)\]', '[^$1]' `
+						-replace '/', '[/|\\]'
+				}
+			$gitignore += 'package\.json$'
+			$gitignore += 'package-lock\.json$'
+			$files = @(
+				Get-ChildItem $target -File -Recurse | Where-Object {
+					$_.Extension -eq '.json' -and -not (Select-String -Quiet -Pattern $gitignore -InputObject $_.FullName)
+				}
+			)
+		} else {
+			$files = @(Get-ChildItem $target -File -Recurse | Where-Object { $_.Extension -eq '.json' })
+		}
 		if (-not $files.Count) {
 			Write-Error "No JSON files found in $([System.IO.Path]::GetRelativePath($PWD.Path, $target.FullName))" -ErrorAction Stop
 		}


### PR DESCRIPTION
Relevant scripts now:
- Ignore `.gitignore`-d files, when the script would act on a directory and a `.gitignore` file exists
- Ignore `package.json` and `package-lock.json` if `.gitignore` exists

May not play nice with `.gitignore` files in subdirectories. May also not play nice with Advanced™ `.gitignore` files but I guess we all know no one's using this script on repos with that.

This is an unholy hack and _even I_ hate everything about this.

Resolves #1 tho!

(also ran the prettier on files i haven't opened for ages)